### PR TITLE
view music details page working, notecards appearing

### DIFF
--- a/components/cards/musicCard.js
+++ b/components/cards/musicCard.js
@@ -1,6 +1,8 @@
+/* eslint-disable react/jsx-curly-brace-presence */
 import React from 'react';
 import { Button, Card } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import Link from 'next/link';
 
 function MusicCard({ musicObj }) {
   return (
@@ -12,8 +14,12 @@ function MusicCard({ musicObj }) {
         <Card.Text>{musicObj.category}</Card.Text>
         <Card.Text>{musicObj.startDate}</Card.Text>
         <Button href={musicObj.recording}>Reference Recording</Button>
-        <Button variant="primary">Details</Button>
-        <Button variant="primary">Edit</Button>
+        <Link href={`/music/${musicObj.firebaseKey}`} passHref>
+          <Button variant="primary">Details</Button>
+        </Link>
+        <Link href={`/music/edit/${musicObj.firebaseKey}`} passHref>
+          <Button variant="primary">Edit</Button>
+        </Link>
         <Button variant="primary">Delete</Button>
       </Card.Body>
     </Card>
@@ -28,6 +34,7 @@ MusicCard.propTypes = {
     category: PropTypes.string,
     startDate: PropTypes.string,
     recording: PropTypes.string,
+    firebaseKey: PropTypes.string,
   }).isRequired,
 };
 

--- a/components/cards/noteCard.js
+++ b/components/cards/noteCard.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Button, Card } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import Link from 'next/link';
+
+function NoteCard({ noteObj }) {
+  return (
+    <Card style={{ width: '18rem' }}>
+      <Card.Body>
+        <Card.Text>{noteObj.noteClosed && <span>CHECK MARK<br /></span>}</Card.Text>
+        <Card.Title>Notepad Date: {noteObj.date}</Card.Title>
+        <Link href={`/music/${noteObj.firebaseKey}`} passHref>
+          <Button variant="primary">Details</Button>
+        </Link>
+        <Link href={`/notepad/edit/${noteObj.firebaseKey}`} passHref>
+          <Button variant="primary">Edit</Button>
+        </Link>
+        <Button variant="primary">Delete</Button>
+      </Card.Body>
+    </Card>
+  );
+}
+
+NoteCard.propTypes = {
+  noteObj: PropTypes.shape({
+    noteClosed: PropTypes.bool,
+    date: PropTypes.string,
+    firebaseKey: PropTypes.string,
+  }).isRequired,
+};
+
+export default NoteCard;

--- a/pages/music/[firebaseKey].js
+++ b/pages/music/[firebaseKey].js
@@ -1,0 +1,40 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import { viewMusicDetails } from '../../api/mergedData';
+import NoteCard from '../../components/cards/noteCard';
+
+function ViewMusicDetails() {
+  const [musicDetails, setMusicDetails] = useState({});
+  const router = useRouter();
+  const { firebaseKey } = router.query;
+  const getMusicDeats = () => {
+    viewMusicDetails(firebaseKey).then(setMusicDetails);
+  };
+  useEffect(() => {
+    getMusicDeats();
+  }, []);
+
+  return (
+    <div className="mt-5 d-flex flex-wrap">
+      <div className="text-white ms-5 details">
+        <h1>
+          {musicDetails?.name} {musicDetails?.musicCompleted ? 'STAR' : ''}
+        </h1>
+        <h4>
+          Written by {musicDetails?.composer}
+        </h4>
+        <h5>
+          Category: {musicDetails?.category}
+        </h5>
+      </div>
+      <div className="d-flex flex-wrap">
+        {musicDetails.notes?.map((notepad) => (
+          <NoteCard key={notepad.firebaseKey} noteObj={notepad} onUpdate={getMusicDeats} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ViewMusicDetails;

--- a/pages/music/edit/[firebaseKey].js
+++ b/pages/music/edit/[firebaseKey].js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+function EditMusicDetails() {
+  return (
+    <h1>Edit Details Page</h1>
+  );
+}
+
+export default EditMusicDetails;

--- a/utils/data/notepad.json
+++ b/utils/data/notepad.json
@@ -4,7 +4,7 @@
   "date":"4/17/2023",
   "jotSheet":"mauris sit amet eros suspendisse accumsan tortor quis turpis sed ante vivamus",
   "noteClosed":false,
-  "musicId":"-NjY4ibfois_XwKusN5A",
+  "musicId":"-NjY4ibb5kmp7o3S_Apj",
   "uid":"9JhFSvTvMvQ7pXrW2ZqqpQSmQfm1"
 },
 "-NjYGhjiqq9r89eUOc4t":{ 
@@ -12,7 +12,7 @@
   "date":"5/17/2023",
   "jotSheet":"ac nulla sed vel enim sit amet nunc",
   "noteClosed":true,
-  "musicId":"-NjY4ibdrzlln2ATa7Nq",
+  "musicId":"-NjY4ibcW9W-Ad1QIdji",
   "uid":"9JhFSvTvMvQ7pXrW2ZqqpQSmQfm1"
 },
 "-NjYGhjj5CC7Zk39FHT9":{
@@ -20,7 +20,7 @@
   "date":"6/5/2023",
   "jotSheet":"ligula sit amet eleifend pede libero quis orci nullam molestie nibh in lectus pellentesque at nulla suspendisse potenti cras in purus eu magna",
   "noteClosed":true,
-  "musicId":"-NjY4ibg8qvhg1neI9vR",
+  "musicId":"-NjY4ibcW9W-Ad1QIdjj",
   "uid":"9JhFSvTvMvQ7pXrW2ZqqpQSmQfm1"
 },
 "-NjYGhjkmKFJa0b4zGJ7":{
@@ -28,7 +28,7 @@
   "date":"6/4/2023",
   "jotSheet":"neque vestibulum eget vulputate ut ultrices vel augue vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae donec pharetra magna vestibulum aliquet ultrices",
   "noteClosed":true,
-  "musicId":"-NjY4ibdrzlln2ATa7Nr",
+  "musicId":"-NjY4ibdrzlln2ATa7Nq",
   "uid":"9JhFSvTvMvQ7pXrW2ZqqpQSmQfm1"
 },
 "-NjYGhjlPcN36uiYuB6D":{
@@ -44,7 +44,7 @@
   "date":"6/17/2023",
   "jotSheet":"volutpat sapien arcu sed augue aliquam erat volutpat in congue etiam justo etiam",
   "noteClosed":false,
-  "musicId":"-NjY4ibfois_XwKusN59",
+  "musicId":"-NjY4ibeF-iguktiAptk",
   "uid":"9JhFSvTvMvQ7pXrW2ZqqpQSmQfm1"
 },
 "-NjYGhjmq10BKjQUxgHh":{
@@ -60,14 +60,14 @@
   "date":"1/9/2023",
   "jotSheet":"lectus in est risus auctor sed tristique in tempus sit amet sem fusce consequat nulla nisl nunc",
   "noteClosed":true,
-  "musicId":"-NjY4ibfois_XwKusN59",
+  "musicId":"-NjY4ibeF-iguktiAptl",
   "uid":"9JhFSvTvMvQ7pXrW2ZqqpQSmQfm1"
 },
 "-NjYGhjo8Mv73TJ_Ze4C":{
   "firebaseKey":"-NjYGhjo8Mv73TJ_Ze4C",
   "date":"1/17/2023",
   "jotSheet":"quam nec dui luctus rutrum nulla tellus in sagittis dui vel nisl duis ac nibh fusce lacus purus aliquet at feugiat","noteClosed":false,
-  "musicId":"-NjY4ibdrzlln2ATa7Nr",
+  "musicId":"-NjY4ibfois_XwKusN59",
   "uid":"9JhFSvTvMvQ7pXrW2ZqqpQSmQfm1"
 },
 "-NjYGhjp-RbE9ATi_gUo":{


### PR DESCRIPTION
## Description
User is now able to view music details page for a piece of music including notecards that are associated with the piece of music. 

## Related Issue
This is related to issue ticket #12 

## Motivation and Context
User is able to see details regarding a piece of music. Still need to work on CSS and ensuring all data is there. 

## How Can This Be Tested?
Tested on local device. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
